### PR TITLE
Add slash between src and ** to allow ** to delve into child folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,12 @@ dist
 
 # Ignore the output video from Git but not videos you import into src/.
 *.mp4
-!src**/*.mp4
+!src/**/*.mp4
 *.mp3
-!src**/*.mp3
+!src/**/*.mp3
 *.webm
-!src**/*.webm
+!src/**/*.webm
 *.aac
-!src**/*.aac
+!src/**/*.aac
 *.wav
-!src**/*.wav
+!src/**/*.wav


### PR DESCRIPTION
Tested by dragging around a .mp4 file and seeing what files are tracked by git. :+1: