### PR TITLE
Fix render video Github Actions workflow + artifact upload output path

### DIFF
--- a/.github/workflows/render-video.yml
+++ b/.github/workflows/render-video.yml
@@ -20,10 +20,10 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install ffmpeg
       - run: npm i
-      - run: echo $WORKFLOW_INPUT > renderProps.json
+      - run: echo $WORKFLOW_INPUT > input-props.json
         env:
           WORKFLOW_INPUT: ${{ toJson(github.event.inputs) }}
-      - run: npm run build -- --props="./renderProps.json"
+      - run: npm run build -- --props="./input-props.json"
       - uses: actions/upload-artifact@v2
         with:
           name: out.mp4

--- a/.github/workflows/render-video.yml
+++ b/.github/workflows/render-video.yml
@@ -20,10 +20,11 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install ffmpeg
       - run: npm i
-      - run: npm run build -- --props=$WORKFLOW_INPUT"
+      - run: echo $WORKFLOW_INPUT > renderProps.json
         env:
           WORKFLOW_INPUT: ${{ toJson(github.event.inputs) }}
+      - run: npm run build -- --props="./renderProps.json"
       - uses: actions/upload-artifact@v2
         with:
           name: out.mp4
-          path: out.mp4
+          path: out/video.mp4


### PR DESCRIPTION
Hello contributors,

This pull request to solve issue #5.

I'm exporting the build variables into an intermediate json file to bypass JSON formatting limitation in the build command.

By the way, I noticed a wrong output path in the artifact upload step, so I fixed too.

Thank's in advance for the PR.
Olivier